### PR TITLE
Use valid category value in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,6 +4,6 @@ author=keestux,SODAQ
 maintainer=Kees Bakker <kees@sodaq.com>
 sentence=An Arduino library for the AT45DB dataflash as used on SODAQ boards.
 paragraph=It supports reading and writing to pages via buf1
-category=Storage
+category=Data Storage
 url=https://github.com/SodaqMoja/Sodaq_dataflash
 architectures=*


### PR DESCRIPTION
Fixes the `WARNING: Category 'Storage' in library Sodaq_dataflash is not valid. Setting to 'Uncategorized'` warning in Arduino IDE 1.6.6 and onwards.