### PR TITLE
Added support for more chips and detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,5 +24,4 @@ Sodaq Moja has an on board AT45DB161D.  An earlier
 development board Sodaq V2 has an AT45DB081D.  If
 you disable the chip-detection, you may
 want to check Sodaq_dataflash.h and verify that the
-correct variant of the AT45DB is selected.  Perhaps
-someday we can detect this dynamically.
+correct variant of the AT45DB is selected.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ disabled by the init() function.
 It is possible to #define the chip in your code
 (detection disabled), rather then in the header
 file, but it might be tricky to get it work with
-Arduino IDE.
+Arduino IDE. If you disable the chip-detection, you
+may want to check Sodaq_dataflash.h and verify that
+the correct variant of the AT45DB is selected.
 
 Use uint8_t df_page_addr_bits(), uint16_t df_page_size()
 and uint8_t df_page_bits() rather then
@@ -21,7 +23,4 @@ and uint8_t df_page_bits() rather then
 enabled!
 
 Sodaq Moja has an on board AT45DB161D.  An earlier
-development board Sodaq V2 has an AT45DB081D.  If
-you disable the chip-detection, you may
-want to check Sodaq_dataflash.h and verify that the
-correct variant of the AT45DB is selected.
+development board Sodaq V2 has an AT45DB081D.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ disabled by the init() function.
 
 It is possible to #define the chip in your code
 (detection disabled), rather then in the header
-file, but it might be tricky to get it to work with
+file, but it might be tricky to get it work with
 Arduino IDE.
 
 Use uint8_t df_page_addr_bits(), uint16_t df_page_size()

--- a/README.md
+++ b/README.md
@@ -4,8 +4,25 @@ The code was developed to be used for the Sodaq Moja
 board.  But it is general purpose, so it can be used
 in other environments too.
 
+Should work for AT45DB011D, AT45DB021D, AT45DB041D,
+AT45DB081D, AT45DB161D, AT45DB321D and AT45DB642D.
+The library detects the chip by default, but can be
+disabled by the init() function.
+
+It is possible to #define the chip in your code
+(detection disabled), rather then in the header
+file, but it might be tricky to get it to work with
+Arduino IDE.
+
+Use uint8_t df_page_addr_bits(), uint16_t df_page_size()
+and uint8_t df_page_bits() rather then
+#define DF_PAGE_ADDR_BITS, #define DF_PAGE_SIZE and
+#define DF_PAGE_BITS in your code, when detection is
+enabled!
+
 Sodaq Moja has an on board AT45DB161D.  An earlier
-development board Sodaq V2 has an AT45DB081D.  You may
+development board Sodaq V2 has an AT45DB081D.  If
+you disable the chip-detection, you may
 want to check Sodaq_dataflash.h and verify that the
 correct variant of the AT45DB is selected.  Perhaps
 someday we can detect this dynamically.

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ Arduino IDE.
 
 Use uint8_t df_page_addr_bits(), uint16_t df_page_size()
 and uint8_t df_page_bits() rather then
-#define DF_PAGE_ADDR_BITS, #define DF_PAGE_SIZE and
-#define DF_PAGE_BITS in your code, when detection is
+ #define DF_PAGE_ADDR_BITS, #define DF_PAGE_SIZE and
+ #define DF_PAGE_BITS in your code, when detection is
 enabled!
 
 Sodaq Moja has an on board AT45DB161D.  An earlier

--- a/examples/diagnostic/diagnostic.ino
+++ b/examples/diagnostic/diagnostic.ino
@@ -23,6 +23,15 @@
  * also be used as the start of a utility to diagnose the dataflash.
  */
 
+/*
+ * Since the library now detects the chip by default, use
+ * uint8_t df_page_addr_bits(), uint16_t df_page_size() and uint8_t df_page_bits(),
+ * rather then
+ * #define DF_PAGE_ADDR_BITS, #define DF_PAGE_SIZE and #define DF_PAGE_BITS!
+ * Please substiute corresponding macros in this example, or disable
+ * detection with the init() function and #define chip!
+ */
+
 #include <Arduino.h>
 #include <SPI.h>
 #include <Sodaq_dataflash.h>

--- a/src/Sodaq_dataflash.cpp
+++ b/src/Sodaq_dataflash.cpp
@@ -62,7 +62,6 @@ void Sodaq_Dataflash::init(uint8_t csPin)
   _pageAddrShift = 1;
 #elif DF_VARIANT == DF_AT45DB161D
   _pageAddrShift = 1;
-// Adding AT45DB041D:
 #elif DF_VARIANT == DF_AT45DB041D
   _pageAddrShift = 1;
 #endif

--- a/src/Sodaq_dataflash.cpp
+++ b/src/Sodaq_dataflash.cpp
@@ -62,6 +62,9 @@ void Sodaq_Dataflash::init(uint8_t csPin)
   _pageAddrShift = 1;
 #elif DF_VARIANT == DF_AT45DB161D
   _pageAddrShift = 1;
+// Adding AT45DB041D:
+#elif DF_VARIANT == DF_AT45DB041D
+  _pageAddrShift = 1;
 #endif
 }
 
@@ -255,6 +258,13 @@ void Sodaq_Dataflash::setPageAddr(unsigned int pageAddr)
  *    followed by three address bytes consist of 2 don’t care bits, 12 page
  *    address bits (PA11 - PA0) that specify the page in the main memory to
  *    be written and 10 don’t care bits."
+ */
+/*
+ * From the AT45DB041D documentation
+ *   "For the DataFlash standard page size (264-bytes), the opcode must be
+ *   followed by three address bytes consist of four don’t care bits, 11 page
+ *   address bits (PA10 - PA0) that specify the page in the main memory to
+ *   be written and nine don’t care bits."
  */
 uint8_t Sodaq_Dataflash::getPageAddrByte0(uint16_t pageAddr)
 {

--- a/src/Sodaq_dataflash.h
+++ b/src/Sodaq_dataflash.h
@@ -24,18 +24,61 @@
 #include <stdint.h>
 #include <SPI.h>
 
-#define DF_AT45DB081D   1
-#define DF_AT45DB161D   2
+#define DF_AT45DB011D   1
+#define DF_AT45DB021D   2
 #define DF_AT45DB041D   3
+#define DF_AT45DB081D   4
+#define DF_AT45DB161D   5
+#define DF_AT45DB321D   6
+#define DF_AT45DB642D   7
 
 #ifndef DF_VARIANT
 #define DF_VARIANT DF_AT45DB161D
 #endif
 
-#if DF_VARIANT == DF_AT45DB081D
+#if DF_VARIANT == DF_AT45DB011D
+// configuration for the Atmel AT45DB011D device
+#define DF_PAGE_ADDR_BITS       9    //DF_PAGE_ADDR_BITS are not used by library
+#define DF_PAGE_SIZE            264  //DF_PAGE_SIZE are not used by library
+#define DF_PAGE_BITS            9
+/*
+ * From AT45DB011D documentation
+ *   "For the DataFlash standard page size (264-bytes), the opcode must be
+ *   followed by three address bytes consist of five don’t care bits, nine page
+ *   address bits (PA8 - PA0) that specify the page in the main memory to
+ *   be written and nine don’t care bits."
+ */
+
+#elif DF_VARIANT == DF_AT45DB021D
+// configuration for the Atmel AT45DB021D device
+#define DF_PAGE_ADDR_BITS       10   //DF_PAGE_ADDR_BITS are not used by library
+#define DF_PAGE_SIZE            264  //DF_PAGE_SIZE are not used by library
+#define DF_PAGE_BITS            9
+/*
+ * From AT45DB021D documentation
+ *   "For the DataFlash standard page size (264-bytes), the opcode must be
+ *   followed by three address bytes consist of five don’t care bits, 10 page
+ *   address bits (PA9 - PA0) that specify the page in the main memory to
+ *   be written and nine don’t care bits."
+ */
+
+#elif DF_VARIANT == DF_AT45DB041D
+// configuration for the Atmel AT45DB041D device
+#define DF_PAGE_ADDR_BITS       11   //DF_PAGE_ADDR_BITS are not used by library
+#define DF_PAGE_SIZE            264  //DF_PAGE_SIZE are not used by library
+#define DF_PAGE_BITS            9
+/*
+ * From AT45DB041D documentation
+ *   "For the DataFlash standard page size (264-bytes), the opcode must be
+ *   followed by three address bytes consist of four don’t care bits, 11 page
+ *   address bits (PA10 - PA0) that specify the page in the main memory to
+ *   be written and nine don’t care bits."
+ */
+
+#elif DF_VARIANT == DF_AT45DB081D
 // configuration for the Atmel AT45DB081D device, Sodaq v2 has AT45DB081D, see doc3596.pdf, 4096 pages of 256/264 bytes
-#define DF_PAGE_ADDR_BITS       12
-#define DF_PAGE_SIZE            264
+#define DF_PAGE_ADDR_BITS       12   //DF_PAGE_ADDR_BITS are not used by library
+#define DF_PAGE_SIZE            264  //DF_PAGE_SIZE are not used by library
 #define DF_PAGE_BITS            9
 /*
  * From the AT45DB081D documentation (other variants are not really identical)
@@ -47,8 +90,8 @@
 
 #elif DF_VARIANT == DF_AT45DB161D
 // configuration for the Atmel AT45DB161D device
-#define DF_PAGE_ADDR_BITS       12
-#define DF_PAGE_SIZE            528
+#define DF_PAGE_ADDR_BITS       12   //DF_PAGE_ADDR_BITS are not used by library
+#define DF_PAGE_SIZE            528  //DF_PAGE_SIZE are not used by library
 #define DF_PAGE_BITS            10
 /*
  * From the AT45DB161B documentation
@@ -58,29 +101,43 @@
  *    be written and 10 don’t care bits."
  */
 
-#elif DF_VARIANT == DF_AT45DB041D
-// configuration for the Atmel AT45DB041D device
-#define DF_PAGE_ADDR_BITS       11
-#define DF_PAGE_SIZE            264
-#define DF_PAGE_BITS            9
+#elif DF_VARIANT == DF_AT45DB321D
+// configuration for the Atmel AT45DB321D device
+#define DF_PAGE_ADDR_BITS       13   //DF_PAGE_ADDR_BITS are not used by library
+#define DF_PAGE_SIZE            528  //DF_PAGE_SIZE are not used by library
+#define DF_PAGE_BITS            10
 /*
- * From AT45DB041D documentation
- *   "For the DataFlash standard page size (264-bytes), the opcode must be
- *   followed by three address bytes consist of four don’t care bits, 11 page
- *   address bits (PA10 - PA0) that specify the page in the main memory to
- *   be written and nine don’t care bits."
+ * From AT45DB321D documentation
+ *   "For the standard DataFlash page size (528 bytes), the opcode must be
+ *    followed by three address bytes consist of 1 don’t care bit, 13 page
+ *    address bits (PA12 - PA0) that specify the page in the main memory to
+ *    be written, and 10 don’t care bits."
+ */
+
+#elif DF_VARIANT == DF_AT45DB642D
+// configuration for the Atmel AT45DB642D device
+#define DF_PAGE_ADDR_BITS       13   //DF_PAGE_ADDR_BITS are not used by library
+#define DF_PAGE_SIZE            1056 //DF_PAGE_SIZE are not used by library
+#define DF_PAGE_BITS            11
+/*
+ * From AT45DB642D documentation
+ *   "For the standard DataFlash page size (1056-bytes), the opcode must be
+ *   followed by three address bytes consist of 13 page
+ *   address bits (PA12 -  PA0) that specify the page in the main memory to
+ *   be written and 11 don’t care bits."
  */
 
 #else
 #error "Unknown DF_VARIANT"
 #endif
-#define DF_NR_PAGES     (1 << DF_PAGE_ADDR_BITS)
+#define DF_NR_PAGES     (1 << DF_PAGE_ADDR_BITS) // DF_PAGE_ADDR_BITS and DF_NR_PAGES are not used by library
 
 class Sodaq_Dataflash
 {
 public:
-  void init(uint8_t csPin=SS);
-  void init(uint8_t misoPin, uint8_t mosiPin, uint8_t sckPin, uint8_t ssPin) __attribute__((deprecated("Use: void init(uint8_t csPin=SS)")));
+  uint8_t init(uint8_t csPin=SS);
+  uint8_t init(uint8_t misoPin, uint8_t mosiPin, uint8_t sckPin, uint8_t ssPin) __attribute__((deprecated("Use: void init(uint8_t csPin=SS)")));
+  uint8_t init(uint8_t ssPin, bool detect);
   void readID(uint8_t *data);
   void readSecurityReg(uint8_t *data, size_t size);
 
@@ -97,6 +154,10 @@ public:
 
   void settings(SPISettings settings);
 
+  uint8_t df_page_addr_bits();
+  uint16_t df_page_size();
+  uint8_t df_page_bits();
+
 private:
   uint8_t readStatus();
   void waitTillReady();
@@ -107,10 +168,18 @@ private:
   uint8_t getPageAddrByte0(uint16_t pageAddr);
   uint8_t getPageAddrByte1(uint16_t pageAddr);
   uint8_t getPageAddrByte2(uint16_t pageAddr);
+  uint8_t chipdetect();
 
   uint8_t _csPin;
-  size_t _pageAddrShift;
+  size_t _pageAddrShift; //Set to 1 in Sodaq_dataflash.cpp, but not used
   SPISettings _settings;
+  static bool willdetect;
+  static uint8_t dfpagebits;
+  static uint8_t chip;
+
+  static const uint8_t df_page_addr_bits_array[];
+  static const uint16_t df_page_size_array[];
+  static const uint8_t df_page_bits_array[];
 };
 
 extern Sodaq_Dataflash dflash;

--- a/src/Sodaq_dataflash.h
+++ b/src/Sodaq_dataflash.h
@@ -26,10 +26,11 @@
 
 #define DF_AT45DB081D   1
 #define DF_AT45DB161D   2
-// Adding AT45DB041D:
-#define DF_AT45DB161D   3
+#define DF_AT45DB041D   3
 
-#define DF_VARIANT      DF_AT45DB161D
+#ifndef DF_VARIANT
+#define DF_VARIANT DF_AT45DB161D
+#endif
 
 #if DF_VARIANT == DF_AT45DB081D
 // configuration for the Atmel AT45DB081D device, Sodaq v2 has AT45DB081D, see doc3596.pdf, 4096 pages of 256/264 bytes
@@ -57,7 +58,6 @@
  *    be written and 10 don’t care bits."
  */
 
-// Adding AT45DB041D:
 #elif DF_VARIANT == DF_AT45DB041D
 // configuration for the Atmel AT45DB041D device
 #define DF_PAGE_ADDR_BITS       11

--- a/src/Sodaq_dataflash.h
+++ b/src/Sodaq_dataflash.h
@@ -26,6 +26,8 @@
 
 #define DF_AT45DB081D   1
 #define DF_AT45DB161D   2
+// Adding AT45DB041D:
+#define DF_AT45DB161D   3
 
 #define DF_VARIANT      DF_AT45DB161D
 
@@ -53,6 +55,20 @@
  *    followed by three address bytes consist of 2 don’t care bits, 12 page
  *    address bits (PA11 - PA0) that specify the page in the main memory to
  *    be written and 10 don’t care bits."
+ */
+
+// Adding AT45DB041D:
+#elif DF_VARIANT == DF_AT45DB041D
+// configuration for the Atmel AT45DB041D device
+#define DF_PAGE_ADDR_BITS       11
+#define DF_PAGE_SIZE            264
+#define DF_PAGE_BITS            9
+/*
+ * From AT45DB041D documentation
+ *   "For the DataFlash standard page size (264-bytes), the opcode must be
+ *   followed by three address bytes consist of four don’t care bits, 11 page
+ *   address bits (PA10 - PA0) that specify the page in the main memory to
+ *   be written and nine don’t care bits."
  */
 
 #else


### PR DESCRIPTION
I believe I've tested all the new parts of the code, but not on any other hardware then my AT45DB041D.

I see the datasheets show the command sets are common for them all. Perhaps the different number of don't care bits for the different chips could cause problems. Maybe Kees can expand on this?

Hopefully somebody have different types off chips they can test?  It would be very nice to get some reports!

It seems that the AT45DBxxxE-series is software incompatible with the D-series. I've not checked earlier series. If earlier series are compatible, I should probably add support for them as well. Please tell me, if you think they are!

Best regards
Bjørn Rasmussen